### PR TITLE
Fixed typo for creating new databases

### DIFF
--- a/zappa_django_utils/management/commands/create_pg_db.py
+++ b/zappa_django_utils/management/commands/create_pg_db.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         host = settings.DATABASES['default']['HOST']
 
         self.stdout.write(self.style.SUCCESS('Connecting to host..'))
-        con = connect(dbname=dbname, user=user, host=host, password=password)
+        con = connect(dbname='postgres', user=user, host=host, password=password)
         con.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
 
         self.stdout.write(self.style.SUCCESS('Creating database'))


### PR DESCRIPTION
When creating new databases on a PostGres server, the database does not yet exist.  So you connection string is hardcoded to connect to the 'postgres' system database, which always exists.