### PR TITLE
Custom User models support (and some PEP8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,16 @@ You'll probably need a default user to manage your application with, so you can 
 
     $ zappa manage <stage> create_admin_user
 
-Now log in with the information that gets returned and immediately change the admin user's email and password.
+Or you can pass some arguments:
+   
+    $ zappa manage <stage> create_admin_user one two three
+
+This will internally make this call:
+```python
+User.objects.create_superuser('one', 'two', 'three')
+```
+
+Now log in and immediately change the admin user's email and password.
 
 ### Creating/Dropping a Postgres Schema
 

--- a/zappa_django_utils/management/commands/create_admin_user.py
+++ b/zappa_django_utils/management/commands/create_admin_user.py
@@ -8,13 +8,26 @@ import string
 class Command(BaseCommand):
     help = 'Creates a default "admin" user'
 
+    def add_arguments(self, parser):
+        parser.add_argument('arguments', nargs='*')
+
     def handle(self, *args, **options):
         # see: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#referencing-the-user-model
         User = get_user_model()
 
-        pw = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+        self.stdout.write(self.style.SUCCESS('Creating new admin user...'))
 
-        self.stdout.write(self.style.SUCCESS('Creating new admin user..'))
-        User.objects.create_superuser('admin', 'admin@admin.com', pw)
-        self.stdout.write(self.style.SUCCESS('Created user "admin", email: "admin@admin.com", password: ' + pw))
-        self.stdout.write(self.style.SUCCESS('Log in and change this password immediately!'))
+        # if the command args are given -> try to create user with given args
+        if options['arguments']:
+            try:
+                User.objects.create_superuser(*options['arguments'])
+                self.stdout.write(self.style.SUCCESS('Created user with given params'))
+            except Exception as e:
+                self.stdout.write(str(e))
+
+        # or create default admin user
+        else:
+            pw = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+            User.objects.create_superuser('admin', 'admin@admin.com', pw)
+            self.stdout.write(self.style.SUCCESS('Created user "admin", email: "admin@admin.com", password: ' + pw))
+            self.stdout.write(self.style.SUCCESS('Log in and change this password immediately!'))

--- a/zappa_django_utils/management/commands/create_admin_user.py
+++ b/zappa_django_utils/management/commands/create_admin_user.py
@@ -1,14 +1,16 @@
-from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
-from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
 
 import random
 import string
+
 
 class Command(BaseCommand):
     help = 'Creates a default "admin" user'
 
     def handle(self, *args, **options):
+        # see: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#referencing-the-user-model
+        User = get_user_model()
 
         pw = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
 

--- a/zappa_django_utils/management/commands/create_pg_db.py
+++ b/zappa_django_utils/management/commands/create_pg_db.py
@@ -1,7 +1,8 @@
 from psycopg2 import connect
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.conf import settings
+
 
 class Command(BaseCommand):
     help = 'Creates the initial Postgres database'

--- a/zappa_django_utils/management/commands/create_pg_schema.py
+++ b/zappa_django_utils/management/commands/create_pg_schema.py
@@ -1,6 +1,6 @@
 from psycopg2 import connect
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.conf import settings
 
 

--- a/zappa_django_utils/management/commands/drop_pg_schema.py
+++ b/zappa_django_utils/management/commands/drop_pg_schema.py
@@ -1,6 +1,6 @@
 from psycopg2 import connect
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.conf import settings
 
 


### PR DESCRIPTION
Hey!
I've added custom User models support and fixed some PEP8 errors

## Context
`create_admin_user` command does not work with a [custom User model](https://docs.djangoproject.com/en/1.11/topics/auth/customizing/).

## Expected Behavior
Successful creation of superuser

## Actual Behavior
It fails :(
```
$ zappa manage dev create_admin_user
Creating new admin user..
Manager isn't available; 'auth.User' has been swapped for 'users.User': AttributeError
Traceback (most recent call last):
  File "/var/task/handler.py", line 553, in lambda_handler
    return LambdaHandler.lambda_handler(event, context)
  File "/var/task/handler.py", line 240, in lambda_handler
    return handler.handler(event, context)
  File "/var/task/handler.py", line 395, in handler
    management.call_command(*event['manage'].split(' '))
  File "/var/task/django/core/management/__init__.py", line 130, in call_command
    return command.execute(*args, **defaults)
  File "/var/task/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/var/task/zappa_django_utils/management/commands/create_admin_user.py", line 16, in handle
    User.objects.create_superuser('admin', 'admin@admin.com', pw)
  File "/var/task/django/db/models/manager.py", line 198, in __get__
    cls._meta.swapped,
AttributeError: Manager isn't available; 'auth.User' has been swapped for 'users.User'
```


## Solution

> Instead of referring to User directly, you should reference the user model using django.contrib.auth.get_user_model(). This method will return the currently active user model – the custom user model if one is specified, or User otherwise. ([django docs](https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#referencing-the-user-model))
 
So, instead of 
```python
from django.contrib.auth.models import User
```
we use
```python
from django.contrib.auth import get_user_model
User = get_user_model()
```
